### PR TITLE
correct signed integer range

### DIFF
--- a/chapter10.tex
+++ b/chapter10.tex
@@ -156,7 +156,7 @@ boolean & \texttt{{\bf variable} my\_test : {\bf boolean} := {\bf false};} & Non
 \section{Integer Types}
 The use of integer types aids in the design of algorithmic-type VHDL code. This type of coding allows VHDL to describe the behaviour of complex digital circuits. As you progress in your digital studies, you will soon find yourself in need of more complex descriptive VHDL tools. Data types such as integers partially fill that desire. This section briefly looks at integer types as well as the definition of user-specified integer types.
 
-The range of the integer type is (-2,147,483,647 to 2,147,483,647). These numbers should seem familiar since they represent the standard 32-bit range for a signed number: from $-(2^{31}-1)$ to $+(2^{31}-1)$. Other types similar to integers include natural and positive types. These types are basically integers with shifted ranges. For example, the natural and positive types range from 0 and 1 to the full 31-bit range, respectively. Examples of integer declarations are shown in the following listing.
+The range of the integer type is (-2,147,483,648 to 2,147,483,647). These numbers should seem familiar since they represent the standard 32-bit range for a signed number: from $-(2^{31})$ to $+(2^{31}-1)$. Other types similar to integers include natural and positive types. These types are basically integers with shifted ranges. For example, the natural and positive types range from 0 and 1 to the full 31-bit range, respectively. Examples of integer declarations are shown in the following listing.
 \vspace{8pt}
 
 \noindent


### PR DESCRIPTION
negative numbers are usually represented as 2's complement giving one more
negative integer than positive.

(there are spelling mistakes in the commit message ._.)
