### PR TITLE
Fixed typo in captions for listings 2.5 and 2.6

### DIFF
--- a/chapter2.tex
+++ b/chapter2.tex
@@ -91,7 +91,7 @@ Remember, intelligent choices for identifiers make your VHDL code more readable,
 \noindent
 \begin{minipage}[lt]{0.49\linewidth}
 \vspace{5pt}
-\begin{lstlisting}[label=valid_identif, caption=Valid identifies.]
+\begin{lstlisting}[label=valid_identif, caption=Valid identifiers.]
 data_bus	--descriptive name
 WE			--classic write enable
 div_flag	--real winner
@@ -109,7 +109,7 @@ mem_read_data
 \begin{minipage}[tr]{0.49\linewidth}
 \vspace{5pt}
 \begin{flushright}
-\begin{lstlisting}[label=invalid_identif, caption=Invalid identifies.]
+\begin{lstlisting}[label=invalid_identif, caption=Invalid identifiers.]
 3Bus_val -- begins with a number
 DDD      -- not self commenting
 mid_$num -- illegal character


### PR DESCRIPTION
Minor typo fix to the captions for Listings 2.5 and 2.6