### PR TITLE
Removed reference to Xilinx ISE

### DIFF
--- a/chapter3.tex
+++ b/chapter3.tex
@@ -178,7 +178,7 @@ end my_arch;
 \end{lstlisting}
 \end{minipage}
 
-Once these packages have been included, you will have access to a very large set of goodies: several data types, overloaded operators, various conversion functions, math functions and so on. For instance, the inclusion of the package \texttt{numeric\_std.all} will give you the possibility of using the \texttt{unsigned} data type and the function \texttt{to\_unsigned} shown in Listing~\ref{main_vhdl_lib}. For a detailed description of what these libraries include, refer to the \texttt{Language Templates} of your favorite synthesis software tool (e.g. the yellow light bulb in the top panel of the Xilinx ISE software tool).
+Once these packages have been included, you will have access to a very large set of goodies: several data types, overloaded operators, various conversion functions, math functions and so on. For instance, the inclusion of the package \texttt{numeric\_std.all} will give you the possibility of using the \texttt{unsigned} data type and the function \texttt{to\_unsigned} shown in Listing~\ref{main_vhdl_lib}. For a detailed description of what these libraries include, refer to the \texttt{Language Templates} of your favorite synthesis software tool.
 
 For more information on VHDL standard libraries refer to the Appendix.
 


### PR DESCRIPTION
Xilinx ISE has been replaced by Xilinx Vivado.  I'm unsure where the language templates are in Xilinx Vivado, so I just removed the reference to ISE.