### PR TITLE
Deleting *~* has dangerous side-effects on Windows. Do not do this.

### DIFF
--- a/clean.cmd
+++ b/clean.cmd
@@ -10,5 +10,5 @@ del *.tex~ *.sty~
 
 del -R __MACOSX
 
-del *~*
+REM del *~*
 


### PR DESCRIPTION
Fixes #39