### PR TITLE
Add Github Action to automatically build the PDF.

### DIFF
--- a/.github/actions/latex/Dockerfile
+++ b/.github/actions/latex/Dockerfile
@@ -1,0 +1,6 @@
+FROM mrchoke/texlive:2023.9
+
+RUN apt update && apt install -y fonts-arkpandora fonts-liberation2
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/latex/Dockerfile
+++ b/.github/actions/latex/Dockerfile
@@ -3,4 +3,6 @@ FROM mrchoke/texlive:2023.9
 RUN apt update && apt install -y fonts-arkpandora fonts-liberation2
 COPY entrypoint.sh /entrypoint.sh
 
+RUN chmod +x /entrypoint.sh
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/latex/action.yml
+++ b/.github/actions/latex/action.yml
@@ -1,0 +1,6 @@
+name: "LaTeX processor"
+description: "LaTeX processor"
+
+runs:
+  using: "docker"
+  image: "Dockerfile"

--- a/.github/actions/latex/entrypoint.sh
+++ b/.github/actions/latex/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -l
+
+bash ./compile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,20 @@
+name: Build Book
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build_book:
+    name: Build book
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Make book
+        uses: ./.github/actions/latex
+      - name: Uploadartifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: free_range_vhdl
+          path: free_range_vhdl.pdf
+          retention-days: 15


### PR DESCRIPTION
This pull request configure Github Actions to build the PDF on each new tag.

To test, do a `git tag 2.0.0` (or any tag you want to use) and then `git push --tags`. An artifact with the produced PDF will be available for 15 days.